### PR TITLE
Change opus engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "node": "12.x"
   },
   "dependencies": {
+    "@discordjs/opus": "^0.1.0",
     "discord.js": "^11.5.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "opusscript": "0.0.7",
     "simple-youtube-api": "^5.2.1",
     "ytdl-core": "^2.1.0",
     "zealcord.js": "^1.1.1"


### PR DESCRIPTION
There was to many issue with `opusscript` as it not for production bot. So I recommend to use `@discordjs/opus` insread where it's more compatible.